### PR TITLE
updates render callback style to follow node convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,19 +117,19 @@ exports.render = function(address, file, options, callback) {
 	options = merge(defaults, options);
 
 	child.supports(function(support){
-		if (!support) callback(true, 'PhantomJS not installed');
+		if (!support) callback(new Error('PhantomJS not installed'));
 
 		var ps = child.exec(address, file, options);
 
 		ps.on('exit', function(c, d){
-			if (c) return callback(true, 'Conversion failed with exit of '+c);
+			if (c) return callback(new Error('Conversion failed with exit of '+c));
 
 			var targetFilePath = file;
 
 			if (targetFilePath[0] != '/')
 				targetFilePath = filePath + '/' + targetFilePath;
 
-			return callback(false, targetFilePath);
+			return callback(null, targetFilePath);
 		});
 	});
 };

--- a/tests/pdf.js
+++ b/tests/pdf.js
@@ -115,7 +115,7 @@ describe('pdf#render()', function(){
 	it('renders a pdf with a callback style', function(d){
 		this.timeout(5000);
 		Pdf.render('http://www.google.com', 'google2.pdf', function(err, file){
-			assert.equal(err, false);
+			assert.equal(err, null);
 			assert.equal(FP + '/google2.pdf', file);
 			d();
 		});


### PR DESCRIPTION
Node callback style is cb(null, obj) on success, and cb(err) on fail – the err is not a boolean, but an error object. 

Handing an error from the render function should check for the existence of the error object, not the value, because that err should be an actual error message or error object.

```
Pdf.render('http://www.google.com', 'google2.pdf', function(err, file){
  if (err) {
    cb(err) //or res.send(err), or whatever error handler you want
  }
  //do whatever with the file
})
```

Otherwise, the error handler has to assume that `file` is the error message, which is odd.

[One bit of related reading.](http://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js/) 

I couldn't find anything definitive on this at [Nodejs.org](http://nodejs.org/) ... :( so please correct me if i'm wrong, but this is the way i've always seen it.
