### PR TITLE
Possible fix for shell-quote problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-google.pdf
-yahoo.pdf
+*.pdf
 tests/shoflo.js
 shoflo.js
-google2.pdf
-html.pdf
 node_modules

--- a/render.js
+++ b/render.js
@@ -13,7 +13,11 @@ if (phantom.args.length < 2) {
   console.log('incorrect args');
   phantom.exit();
 } else {
-  var options = JSON.parse(phantom.args[2]);
+  var optionsStr = phantom.args[2];
+  // fix various escapings
+  optionsStr = optionsStr.replace(/\\!/g, '!'); // fix escaping of exclamation mark
+  optionsStr = optionsStr.replace(/\\\\"/g, '\\"'); // fix double escape of quot chars
+  var options = JSON.parse(optionsStr);
 
   contentsCb(options.paperSize.header);
   contentsCb(options.paperSize.footer);

--- a/tests/pdf.js
+++ b/tests/pdf.js
@@ -56,7 +56,29 @@ describe('pdf#content', function() {
       assert.ok(false);
       d();
     });
-  })
+  });
+
+  it('fixes shell escaping in content', function(d){
+    this.timeout(5000);
+    var args = { content: '<html><head><title>PDF</title></head><body class="test"><div></div><!-- some comment --></body></html>' };
+    var pdf = new Pdf(null, 'html2.pdf', args);
+    pdf.on('done', function(file){
+      assert.equal(FP + '/html2.pdf', file);
+      d();
+    });
+
+  });
+
+  it('fixes shell escaping in content (issue #33)', function(d){
+    this.timeout(5000);
+    var args = { content: '<html><body><img src="https://www.google.com/images/srpr/logo11w.png" alt="google"/></body></html>' };
+    var pdf = new Pdf(null, 'html3.pdf', args);
+    pdf.on('done', function(file){
+      assert.equal(FP + '/html3.pdf', file);
+      d();
+    });
+
+  });
 });
 
 describe('pdf#done() 2', function(){


### PR DESCRIPTION
This PR tries to solve https://github.com/TJkrusinski/NodePDF/issues/33. By two regular expressions I try to get around the problem introduced by the behaviour of shell-quote for quote chars `"` and exclamation marks `!`.

There might be a better solution to this problem, but at least for my purposes this fix helps getting the job done. Both test cases work in this way.