### PR TITLE
Encode the options in base64 before being passed to PhantomJS

### DIFF
--- a/child.js
+++ b/child.js
@@ -21,7 +21,7 @@ exports.exec = function(url, filename, options, cb){
     __dirname+'/render.js',
     url,
     filename,
-    JSON.stringify(options),
+    new Buffer(JSON.stringify(options)).toString('base64')
   ]));
 
   return child.exec(stdin.join(' '), function(err, stdo, stde){

--- a/render.js
+++ b/render.js
@@ -13,7 +13,22 @@ if (phantom.args.length < 2) {
   console.log('incorrect args');
   phantom.exit();
 } else {
-  var options = JSON.parse(phantom.args[2]);
+
+  try {
+    var encodedOpts = atob(phantom.args[2]);
+  }
+  catch (e) {
+    console.log("Options are not base64 encoded correctly");
+    phantom.exit();
+  }
+
+  try {
+    var options = JSON.parse(encodedOpts);
+  }
+  catch (e) {
+    console.log("Options are not valid JSON");
+    phantom.exit();
+  }
 
   contentsCb(options.paperSize.header);
   contentsCb(options.paperSize.footer);


### PR DESCRIPTION
I was encountering a bug on Windows where the convert call would just hang forever. I pinned it down to the JSON parse call in render.js -- it was failing because for some reason the quotes had gotten stripped from the JSON string, on the boundary between `child.js` and `render.js`. I fixed this by encoding the JSON in base64 before passing it to Phantom, and then decoding it in `render.js`.